### PR TITLE
Removed a slightly overzealous typehint that causes an error in PHP 7.0…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ _A plugin for Craft CMS 3.x to help distinguish your Craft environments ...so yo
 The format of this file is based on ["Keep a Changelog"](http://keepachangelog.com/). This project adheres to [Semantic Versioning](http://semver.org/). Version numbers follow the pattern: `MAJOR.FEATURE.BUILD`
 
 
+## 3.1.2 - 2018-03-08
+
+### Fixed
+
+- Removed a slightly overzealous typehint that causes an error in PHP 7.0 (since the `void` return type wasn't added until 7.1).
+
+
 ## 3.1.1 - 2017-12-31
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "topshelfcraft/environment-label",
     "description": "...so you don't forget where you are.",
     "type": "craft-plugin",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "keywords": [
         "craft",
         "cms",

--- a/src/services/Label.php
+++ b/src/services/Label.php
@@ -161,7 +161,7 @@ class Label extends Component
      * If we're in an authenticated CP request, the label is added to the CP,
 	 * and some JS variables are injected for convenience debugging things in the console.
      */
-    public function doItBaby(): void
+    public function doItBaby()
     {
 
         if (


### PR DESCRIPTION
...(since the `void` return type wasn't added until 7.1).

(This fixes issue #1.)